### PR TITLE
Add append keyword matching for address groups

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,7 @@
 # Change Log
+## [1.1.8]
+
+- Add append matching address groups
 
 ## [1.1.7]
 

--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "name": "fortigate-language-support",
   "displayName": "FortiGate Language Support",
   "description": "Syntax highlighting for FortiGate configuration",
-  "version": "1.1.7",
+  "version": "1.1.8",
   "publisher": "tinyboxvk",
   "license": "MIT",
   "homepage": "https://github.com/tinyboxvk/FortiGate-Language-Support",

--- a/syntaxes/fortigate.tmLanguage.json
+++ b/syntaxes/fortigate.tmLanguage.json
@@ -34,7 +34,7 @@
 			"patterns": [
 				{
 					"name": "keyword.control.fortigate",
-					"match": "^\\s*(?:config [a-zA-Z0-9 -]+|end|edit|next|set|unset)\\b(?!-)"
+					"match": "^\\s*(?:config [a-zA-Z0-9 -]+|end|edit|next|set|unset|append)\\b(?!-)"
 				}
 			]
 		},


### PR DESCRIPTION
Fortigate has the ability to add address object to an existing group by using `append` instead of `set`. 

![image](https://github.com/user-attachments/assets/a8b8e80e-119d-4fcc-a42a-bffd1a697398)
